### PR TITLE
FEATURE: Pass the task entity to the task implementation

### DIFF
--- a/Classes/Ttree/Scheduler/Domain/Model/Task.php
+++ b/Classes/Ttree/Scheduler/Domain/Model/Task.php
@@ -196,7 +196,7 @@ class Task {
 	 */
 	public function execute(ObjectManagerInterface $objectManager) {
 		/** @var TaskInterface $task */
-		$task = $objectManager->get($this->implementation);
+		$task = $objectManager->get($this->implementation, $this);
 		$task->execute($this->arguments);
 		$this->lastExecution = new \DateTime('now');
 		$this->initializeNextExecution();


### PR DESCRIPTION
This change passes the task entity as a constructor argument to
the task implementation. When the task implementation does not
have a constructor this is completely ignored. If it has one it allows
for changing the status of the task.

This can be used to disable a job automatically after execution allowing
for manual execution only.
