### PR TITLE
BUGFIX: */X are not possible in annotations

### DIFF
--- a/Classes/Ttree/Scheduler/Annotations/Schedule.php
+++ b/Classes/Ttree/Scheduler/Annotations/Schedule.php
@@ -34,7 +34,7 @@ final class Schedule
     public function __construct(array $values)
     {
         if (isset($values['expression'])) {
-            $this->expression = (string)$values['expression'];
+            $this->expression = stripslashes((string)$values['expression']);
         } else {
             $this->expression = '* * * * *';
         }


### PR DESCRIPTION
To use */2 in php annotations you have to escape the slash with *\/2. The php function needs to revert the backslash again to have the clean string for the cron command.
