### PR TITLE
TASK: update last and next execution time of tasks after a failed run

### DIFF
--- a/Classes/Domain/Model/Task.php
+++ b/Classes/Domain/Model/Task.php
@@ -222,8 +222,7 @@ class Task
         /** @var TaskInterface $task */
         $task = $objectManager->get($this->implementation, $this);
         $task->execute($this->arguments);
-        $this->lastExecution = new \DateTime('now');
-        $this->initializeNextExecution();
+        $this->markAsRun();
     }
 
     /**
@@ -277,5 +276,11 @@ class Task
     public function setDescription($description)
     {
         $this->description = $description;
+    }
+
+    public function markAsRun()
+    {
+        $this->lastExecution = new \DateTime('now');
+        $this->initializeNextExecution();
     }
 }


### PR DESCRIPTION
If we don't to that, the task is restarted at every cron match. Thus a daily importer is started every
5 minutes and fails with the same error each time. With this patch, the last exection time is set to
the timestamp of the failure, and the next execution time is calculated as normal