### PR TITLE
[TASK] Add Column annotation to description property.

### DIFF
--- a/Classes/Domain/Model/Task.php
+++ b/Classes/Domain/Model/Task.php
@@ -80,6 +80,7 @@ class Task
 
     /**
      * @var string
+     * @ORM\Column(type="text")
      */
     protected $description;
     


### PR DESCRIPTION
Hi,

without this annotation Doctrine wants to convert the description column to VARCHAR(255) instead of using longtext.
This gets in the way if you use ./flow doctrine:migrationgenerate.

Cheers,
David