### PR TITLE
BUGFIX: Slashes in annotation expressions

### DIFF
--- a/Classes/Domain/Model/Task.php
+++ b/Classes/Domain/Model/Task.php
@@ -175,7 +175,9 @@ class Task
      */
     public function setExpression($expression)
     {
-        $this->expression = $expression;
+        /* Slashes in annotaion expressions of dynamic tasks have to be double-escaped due to proxy classes.
+        For the cron expression, the remaining backslash needs to be removed here. */
+        $this->expression = str_replace('\\', '', $expression);
         $this->initializeNextExecution();
     }
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ class MyTask implements \Ttree\Scheduler\Task\TaskInterface {
 This task will be executed every minute. Dynamic task do not support arguments, the ``$arguments`` of the execute method
 is always an empty array.
 
+If your expression contains slashes, you have to double-escape them. I.e. run the task every 5 minutes: `@Scheduler\Schedule(expression="*\\/5 * * * *")`
+
 You can also add a description to your task using the Meta annotation::
 
 ```php


### PR DESCRIPTION
The issue is also discussed in the Flow Slack channel, where it was suggested to double escape the slashes (which than failed later in the code).

Closes #24 