### PR TITLE
TASK: Mark task as run before execution

### DIFF
--- a/Classes/Domain/Model/Task.php
+++ b/Classes/Domain/Model/Task.php
@@ -222,7 +222,6 @@ class Task
         /** @var TaskInterface $task */
         $task = $objectManager->get($this->implementation, $this);
         $task->execute($this->arguments);
-        $this->markAsRun();
     }
 
     /**


### PR DESCRIPTION
If there is a task taking longer than the interval the scheduler task runner is executed, the task is executed again even though it is not scheduled to execute again. Setting the last execution time before executing the task fixes this problem.

Closes #16 