### PR TITLE
Fix calls to undefined methods

### DIFF
--- a/Classes/Command/TaskCommandController.php
+++ b/Classes/Command/TaskCommandController.php
@@ -233,17 +233,6 @@ class TaskCommandController extends CommandController
 
     /**
      * @param Task $task
-     * @param string $taskType
-     */
-    protected function markFailedTaskAsRun(Task $task, $taskType)
-    {
-        $task->setLastExecution(new \DateTime());
-        $task->initializeNextExecution();
-        $this->taskService->update($task, $taskType);
-    }
-
-    /**
-     * @param Task $task
      * @param bool $taskType
      */
     protected function markTaskAsRun(Task $task, $taskType)

--- a/Classes/Command/TaskCommandController.php
+++ b/Classes/Command/TaskCommandController.php
@@ -251,7 +251,7 @@ class TaskCommandController extends CommandController
         $task->markAsRun();
         $this->taskService->update($task, $taskType);
         if ($taskType === TaskInterface::TYPE_PERSISTED) {
-            $this->persistenceManager->whitelistObject($task);
+            $this->persistenceManager->allowObject($task);
             $this->persistenceManager->persistAll(true);
         }
     }


### PR DESCRIPTION
Since `whitelistObject()` got [removed](https://github.com/neos/flow-development-collection/commit/ef5b9d2292c2dc14ee698f18b4480d801e2df169) from PersistenceManagerInterface, I've replaced it with a call to `allowObject()`. The `markFailedTaskAsRun` also contained a call to an undefined method `Task::setLastExecution` but the method itself wasn't used so I removed it as one could just use `markTaskAsRun`.