### PR TITLE
FEATURE: add attribute to annotation classes

### DIFF
--- a/Classes/Annotations/Meta.php
+++ b/Classes/Annotations/Meta.php
@@ -15,6 +15,7 @@ use Neos\Flow\Annotations as Flow;
  * @Annotation
  * @Target("CLASS")
  */
+#[\Attribute(\Attribute::TARGET_CLASS)]
 final class Meta
 {
 

--- a/Classes/Annotations/Schedule.php
+++ b/Classes/Annotations/Schedule.php
@@ -15,6 +15,7 @@ use Neos\Flow\Annotations as Flow;
  * @Annotation
  * @Target("CLASS")
  */
+#[\Attribute(\Attribute::TARGET_CLASS)]
 final class Schedule
 {
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,17 @@ class MyTask implements \Ttree\Scheduler\Task\TaskInterface {
 }
 ```
 
+or
+
+```php
+use Ttree\Scheduler\Annotations as Scheduler;
+
+#[Scheduler\Schedule(["expression" => "* * * * *"])]
+class MyTask implements \Ttree\Scheduler\Task\TaskInterface {
+	// ...
+}
+```
+
 This task will be executed every minute. Dynamic task do not support arguments, the ``$arguments`` of the execute method
 is always an empty array.
 
@@ -47,6 +58,13 @@ use Ttree\Scheduler\Annotations as Scheduler;
 /**
  * @Scheduler\Meta(description="Describes your task.")
  */
+```
+
+or
+
+```php
+use Ttree\Scheduler\Annotations as Scheduler;
+#[Scheduler\Meta(["description" => "Describes your task."])]
 ```
 
 Persisted Tasks


### PR DESCRIPTION
Add attribute to annotation classes so you can do this

```php
use Ttree\Scheduler\Annotations as Scheduler;

#[Scheduler\Schedule(["expression" => "* * * * *"])]
class MyTask implements \Ttree\Scheduler\Task\TaskInterface {
	// ...
}
```

instead of

```php
use Ttree\Scheduler\Annotations as Scheduler;
/**
 * @Scheduler\Schedule(expression="* * * * *")
 */
class MyTask implements \Ttree\Scheduler\Task\TaskInterface {
	// ...
}
```